### PR TITLE
[16.0][FIX] stock_cycle_count: fix multiple issues in location accuracy report

### DIFF
--- a/stock_cycle_count/reports/report_stock_location_accuracy.py
+++ b/stock_cycle_count/reports/report_stock_location_accuracy.py
@@ -6,13 +6,13 @@ from odoo import api, models
 
 
 class LocationAccuracyReport(models.AbstractModel):
-    _name = "report.stock_location_accuracy"
+    _name = "report.stock_cycle_count.stock_location_accuracy"
     _description = "Location Accuracy Report"
 
     @api.model
     def _get_inventory_domain(self, loc_id, exclude_sublocation=True):
         return [
-            ("location_id", "=", loc_id),
+            ("location_ids", "in", [loc_id]),
             ("exclude_sublocation", "=", exclude_sublocation),
             ("filter", "=", "none"),
             ("state", "=", "done"),
@@ -20,18 +20,25 @@ class LocationAccuracyReport(models.AbstractModel):
 
     @api.model
     def _get_location_data(self, locations):
-        data = dict()
-        inventory_obj = self.env["stock.inventory"]
-        location_ids = locations.mapped("id")
-        counts = inventory_obj.search([("location_id", "in", location_ids)])
+        location_data = {}
+        counts = self.env["stock.inventory"].search(
+            [
+                ("location_ids", "in", locations.ids),
+                ("state", "=", "done"),
+            ]
+        )
         for loc in locations:
-            loc_counts = counts.filtered(lambda c: c.location_id == loc)
-            data[loc] = loc_counts
-        return data
+            location_data[loc] = counts.filtered(
+                lambda count: loc in count.location_ids
+            )
+        return location_data
 
-    def render_html(self, data=None):
-        report_obj = self.env["report"]
-        locs = self.env["stock.location"].browse(self._ids)
-        data = self._get_location_data(locs)
-        docargs = {"doc_ids": locs._ids, "docs": locs, "data": data}
-        return report_obj.render("stock_cycle_count.stock_location_accuracy", docargs)
+    def _get_report_values(self, docids, data=None):
+        locations = self.env["stock.location"].browse(docids)
+        location_data = self._get_location_data(locations)
+        return {
+            "doc_ids": locations.ids,
+            "doc_model": "stock.location",
+            "docs": locations,
+            "location_data": location_data,
+        }

--- a/stock_cycle_count/reports/stock_cycle_count_report.xml
+++ b/stock_cycle_count/reports/stock_cycle_count_report.xml
@@ -9,11 +9,11 @@
                     <table class="table table-condensed">
                         <thead>
                             <tr>
-                                <th>Cycle Count #</th>
-                                <th>Location</th>
-                                <th>Required Date</th>
-                                <th>Assigned to</th>
-                                <th>Status</th>
+                                <th class="text-start">Cycle Count #</th>
+                                <th class="text-start">Location</th>
+                                <th class="text-start">Required Date</th>
+                                <th class="text-start">Assigned to</th>
+                                <th class="text-start">Status</th>
                             </tr>
                         </thead>
                         <tbody class="sale_tbody">
@@ -31,7 +31,7 @@
                                     <td>
                                         <span t-field="doc.responsible_id" />
                                     </td>
-                                    <td class="text-right">
+                                    <td>
                                         <span t-field="doc.state" />
                                     </td>
                                 </tr>
@@ -46,6 +46,8 @@
     <record id="action_report_stock_cycle_count" model="ir.actions.report">
         <field name="model">stock.cycle.count</field>
         <field name="report_name">stock_cycle_count.report_cyclecount</field>
+        <field name="report_file">stock_cycle_count.stock_location_accuracy</field>
+        <field name="binding_model_id" ref="model_stock_cycle_count" />
         <field name="name">Cycle Count</field>
         <field name="report_type">qweb-pdf</field>
         <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]" />

--- a/stock_cycle_count/reports/stock_location_accuracy_report.xml
+++ b/stock_cycle_count/reports/stock_location_accuracy_report.xml
@@ -13,40 +13,49 @@
                             <span>Location:</span>
                             <span t-field="doc.name" />
                         </h3>
-                        <div class="row mt32 mb32" id="informations">
-                            <div class="col-xs-6">
-                                <strong>Complete name:</strong>
-                                <p t-field="doc.complete_name" />
+                        <div class="row mt-4 mb-4" id="informations">
+                            <div class="col-auto col-6 mw-100 mb-2">
+                                <strong>Complete Name:</strong>
+                                <p class="m-0" t-field="doc.complete_name" />
                             </div>
-                            <div class="col-xs-3">
+                            <div class="col-auto col-3 mw-100 mb-2">
                                 <strong>Current Accuracy:</strong>
-                                <p t-field="doc.loc_accuracy" />
+                                <p class="m-0">
+                                    <span t-field="doc.loc_accuracy" /><span>%</span>
+                                </p>
                             </div>
                         </div>
-                        <table class="table table-condensed">
-                            <thead>
-                                <tr>
-                                    <th>Inventory</th>
-                                    <th class="text-right">Date</th>
-                                    <th class="text-right">Accuracy</th>
-                                </tr>
-                            </thead>
-                            <tbody class="sale_tbody">
-                                <t t-foreach="data[doc]" t-as="l">
+                        <t t-if="location_data.get(doc)">
+                            <table class="table table-condensed">
+                                <thead>
                                     <tr>
-                                        <td>
-                                            <span t-field="l.name" />
-                                        </td>
-                                        <td class="text-right">
-                                            <span t-field="l.date" />
-                                        </td>
-                                        <td class="text-right">
-                                            <span t-field="l.inventory_accuracy" />
-                                        </td>
+                                        <th class="text-start">Inventory</th>
+                                        <th class="text-start">Date</th>
+                                        <th class="text-end">Accuracy</th>
                                     </tr>
-                                </t>
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody>
+                                    <t t-foreach="location_data[doc]" t-as="l">
+                                        <tr>
+                                            <td>
+                                                <span t-field="l.name" />
+                                            </td>
+                                            <td>
+                                                <span t-field="l.date" />
+                                            </td>
+                                            <td class="text-end">
+                                                <span
+                                                    t-field="l.inventory_accuracy"
+                                                /><span>%</span>
+                                            </td>
+                                        </tr>
+                                    </t>
+                                </tbody>
+                            </table>
+                        </t>
+                        <t t-else="">
+                            <p>No inventory records found for this location.</p>
+                        </t>
                     </div>
                 </t>
             </t>
@@ -55,7 +64,9 @@
     <!-- Report action -->
     <record id="action_report_stock_location_accuracy" model="ir.actions.report">
         <field name="model">stock.location</field>
-        <field name="report_name">stock_location_accuracy</field>
+        <field name="report_name">stock_cycle_count.stock_location_accuracy</field>
+        <field name="report_file">stock_cycle_count.stock_location_accuracy</field>
+        <field name="binding_model_id" ref="stock.model_stock_location" />
         <field name="name">Accuracy Report</field>
         <field name="report_type">qweb-pdf</field>
         <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]" />


### PR DESCRIPTION
Fixes:
- Incorrect field used in domain (`location_id` → `location_ids`)
- Wrong report template name in `ir.actions.report`
- Missing `data` in QWeb rendering context due to incorrect report model name; renamed `report.stock_location_accuracy` → `report.stock_cycle_count.stock_location_accuracy`
- Replaced Bootstrap 4 classes with Bootstrap 5 equivalents in report template
- Removed deprecated `render_html`, replaced with `_get_report_values`, see: `https://github.com/odoo/odoo/pull/39527`

Also improved the display a bit on this occasion:
- Added percentage units to Accuracy values
- left aligned the status and date columns (right aligned for numeric data only)

result: [Accuracy Report.pdf](https://github.com/user-attachments/files/21460649/Accuracy.Report.pdf)
